### PR TITLE
Importing libraries for MemLimiter

### DIFF
--- a/ExplorationTechniques/MemLimiter/MemLimiter.py
+++ b/ExplorationTechniques/MemLimiter/MemLimiter.py
@@ -1,6 +1,8 @@
+import os
+import psutil
 from angr.exploration_techniques import ExplorationTechnique
 
-class MemLimiter(angr.exploration_techniques.ExplorationTechnique):
+class MemLimiter(ExplorationTechnique):
     def __init__(self, max_mem, drop_errored):
         super(MemLimiter, self).__init__()
         self.max_mem = max_mem


### PR DESCRIPTION
MemLimiter doesn't work without importing these libraries. Also, a small fix with parent class name.